### PR TITLE
deleted redefinition of void nextStation()

### DIFF
--- a/Esp32_Internet_Radio_Code.ino
+++ b/Esp32_Internet_Radio_Code.ino
@@ -189,13 +189,6 @@ void nextStation() {
     connectToHost();  // Connect to the new station
 }
 
-
-void nextStation() {
-    currentStation = (currentStation + 1) % totalStations;
-    displayStation();
-    connectToHost();
-}
-
 void previousStation() {
     currentStation = (currentStation - 1 + totalStations) % totalStations;
     displayStation();


### PR DESCRIPTION
two instances of "void nextStation" were causing compile fails.